### PR TITLE
Fix relative file paths not being created on Windows

### DIFF
--- a/module.jai
+++ b/module.jai
@@ -144,6 +144,10 @@ build_ctags :: (filename: string) {
 
 	ctags: CTags;
 	ctags.base_path = get_working_directory();
+
+    // Need forward slashes in order to compare with Code_Node filenames.
+    #if OS == .WINDOWS path_overwrite_separators(ctags.base_path, #char "/");
+
 	defer reset(*ctags);
 
 	while true {


### PR DESCRIPTION
HI Raphael, 

I noticed on Windows that the paths in the tags file were absolute instead of relative. This is happening because `get_working_directory` uses backslashes on Windows and the compiler paths use forward slashes, so the `begins_with` tests fail.